### PR TITLE
Convert options passed into Keyword list

### DIFF
--- a/lib/twilight_informant/http.ex
+++ b/lib/twilight_informant/http.ex
@@ -42,7 +42,7 @@ defmodule TwilightInformant.HTTP do
        path |> build_url,
        body,
        @headers,
-       query_params |> add_api_token |> add_httpoison_opts)
+       params: query_params |> add_api_token |> add_httpoison_opts)
        |> handle_response
   end
 


### PR DESCRIPTION
The `HTTP.request` function expects a Keyword list to be passed with `params` as a key (see https://github.com/edgurgel/httpoison/blob/master/lib/httpoison/base.ex#L152)